### PR TITLE
do not fail on deault removal

### DIFF
--- a/lib/thor-addons/helpers/defaults.rb
+++ b/lib/thor-addons/helpers/defaults.rb
@@ -26,7 +26,7 @@ module ThorAddons
         hash.each_with_object({}) do |(k, v), hsh|
           hsh[k] = nil
 
-          hsh[k] = v unless defaults[k][:value] == v
+          hsh[k] = v unless defaults.include?(k) && defaults[k][:value] == v
         end
       end
     end


### PR DESCRIPTION
this fixes an edge case as it should not happen when you call `Thor.start`
I got the following failure while calling the `invoke` in my CLI specs

```
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # /Users/jacopo/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-addons-1.0.0/lib/thor-addons/helpers/defaults.rb:29:in `block in remove'
     # /Users/jacopo/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-addons-1.0.0/lib/thor-addons/helpers/defaults.rb:26:in `each'
     # /Users/jacopo/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-addons-1.0.0/lib/thor-addons/helpers/defaults.rb:26:in `each_with_object'
     # /Users/jacopo/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-addons-1.0.0/lib/thor-addons/helpers/defaults.rb:26:in `remove'
     # /Users/jacopo/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/thor-addons-1.0.0/lib/thor-addons/options.rb:35:in `options'
```

this was happening as i was passing an invalid option in the `invoke` command