### PR TITLE
remove bad options from config

### DIFF
--- a/spec/lib/thor-addons/helpers/options_config_file_spec.rb
+++ b/spec/lib/thor-addons/helpers/options_config_file_spec.rb
@@ -56,17 +56,17 @@ describe ThorAddons::Helpers::OptionsConfigFile do
     it "should extract the data from th given hash" do
       expect(
         described_class.extract_command_data(data, "cmd_1")
-      ).to eq("foo" => "bar", "biz" => true)
+      ).to eq([{ "foo" => "bar" }, { "biz" => true }])
     end
 
     it "should extract only the global if the command is not present" do
       expect(
         described_class.extract_command_data(data, "cmd_3")
-      ).to eq("foo" => "bar")
+      ).to eq([{ "foo" => "bar" }, {}])
     end
 
     it "should return a empty hash if the command and global not present" do
-      expect(described_class.extract_command_data({}, "cmd_3")).to eq({})
+      expect(described_class.extract_command_data({}, "cmd_3")).to eq([{}, {}])
     end
   end
 


### PR DESCRIPTION
previously if you had any options defined in the config they would have been shown as rejected.
the `get_command_config_data` should select only the option matchign the command called.
This change ensures that