### PR TITLE
bugfix config rejecting keys when command had no options

### DIFF
--- a/lib/thor-addons/helpers/options_config_file.rb
+++ b/lib/thor-addons/helpers/options_config_file.rb
@@ -21,10 +21,12 @@ module ThorAddons
         global_options, cmd_options = extract_command_data(data, commands.shift)
 
         commands.each do |cmd|
-          break if cmd_options[cmd].nil?
+          should_break = cmd_options[cmd].nil?
 
           global, cmd_options = extract_command_data(cmd_options, cmd)
           global_options.merge!(global)
+
+          break if should_break
         end
 
         global_options.merge(cmd_options)

--- a/spec/lib/thor-addons/helpers/options_config_file_spec.rb
+++ b/spec/lib/thor-addons/helpers/options_config_file_spec.rb
@@ -80,6 +80,14 @@ describe ThorAddons::Helpers::OptionsConfigFile do
             "cmd_2"
           )
         ).to eq("foo" => "bar", "fii" => "bii", "goo" => { "a" => "1" })
+
+        expect(
+          described_class.get_command_config_data(
+            data,
+            invocations,
+            "cmd_3"
+          )
+        ).to eq("foo" => "bar", "fii" => "bii")
       end
     end
 


### PR DESCRIPTION
as the break was happening before the global merge options were getting discarded when the command had no key in config